### PR TITLE
randomize new user's password

### DIFF
--- a/src/app/Http/Controllers/UploadController.php
+++ b/src/app/Http/Controllers/UploadController.php
@@ -15,6 +15,7 @@ use App\Auth\EmailAuthentication;
 use App\Models\UserLoginToken;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 
 use SimpleXLSX;
 
@@ -204,7 +205,7 @@ class UploadController extends Controller
     public function dbInsert($firstName, $lastName, $email, $role)
     {
         $user = User::create([
-            'password' => Hash::make('password'),
+            'password' => Hash::make(Str::random(10)),
             'email' => $email,
             'first_name' => $firstName,
             'last_name' => $lastName,


### PR DESCRIPTION
# UPEI Behavior Rating Tool PR

Before creating a pull request, ensure you are not committing broken code and if you have trouble with any particular problem, do not hesitate to contact another group member for assistance.

## What are the contents of this PR?

- [ ] Refactor
- [X] New Feature
- [ ] Optimization
- [ ] Documentation
- [ ] Bug Fix
- [ ] Configuration
- [ ] Breaking Change

## Describe the PR

Up until now every default new user password was "password" for testing purposes.  This of course is not ideal when it comes to account security.  This PR assigns the user with a hashed random string instead, requiring the user to use the email link to gain initial access to their account. 

## Related issue

Closes #145 

## Checklist

- [X] My code follows the same style of the project
- [ ] My code requires an update to the documentation
- [ ] I have updated the documentation as required
- [ ] I have added the required unit/feature tests
- [X] All tests were successful

## Testing

Besides automated testing, please describe how you tested your changes below:
1. Make a new user as you normally would.
2. You should not be able to log into this user using a password of "password".
3. The only way to access this account should be through the link provided through the email sent to that user, where they then set their password.