### PR TITLE
Added email validation if an old email is input but no new email

### DIFF
--- a/src/app/Http/Controllers/AccountController.php
+++ b/src/app/Http/Controllers/AccountController.php
@@ -115,6 +115,13 @@ class AccountController extends Controller
 
     $oldemail = request()->input('old-email');
     $newemail = request()->input('email');
+    $confirmemail = request()->input('email-confirm');
+
+    //make sure the user filled in all the fields
+    if ($newemail === NULL || $confirmemail === NULL) {
+      $email_err_msg = "Please fill in all the fields.";
+      return;
+    }
 
     $user = auth()->user();
     $currentemail = $user->email;

--- a/src/app/Http/Controllers/AccountController.php
+++ b/src/app/Http/Controllers/AccountController.php
@@ -166,6 +166,12 @@ class AccountController extends Controller
 
     $oldpassword = request()->input('old-password');
     $newpassword = request()->input('password');
+    $confirmpassword = request()->input('password-confirm');
+
+    if ($newpassword === NULL || $confirmpassword === NULL) {
+      $password_err_msg = "Please fill in all the fields.";
+      return;
+    }
 
     $user = auth()->user();
 

--- a/src/public/javascript/account.js
+++ b/src/public/javascript/account.js
@@ -1,7 +1,20 @@
 // Emails
+// When old email is input, prompt for new email
+$(document).ready(function(){
+    $("#old-email").on("input", function(){
+        if($("#email").val() == ""){
+            document.getElementById("email").style.borderColor = "red";
+        }
+        if($("#email-confirm").val() == ""){
+            document.getElementById("email-confirm").style.borderColor = "red";
+        }
+    })
+});
+
 // If the new password field is changed, the confirm field gets a red border
 $(document).ready(function(){
     $("#email").on("input", function(){
+        document.getElementById("email").style.borderColor = "#ced4da";
         if($("#email").val() != "" && $("#email").val() != $("#email-confirm").val()){
           document.getElementById("email-confirm").style.borderColor = "red";
         } else {
@@ -49,6 +62,12 @@ $(document).ready(function(){
 function validate(event) {
     var mismatch_email = true;
     var mismatch_password = true;
+    // If old email is filled in and new email is empty
+    if($("#old-email").val() != "" && $("#email").val() == ""){
+        event.preventDefault();
+        alert("Please enter a new email or remove your old email");
+    }
+
     // Email validation
     var email = $("#email").val();
     var emailconf = $("#email-confirm").val();

--- a/src/public/javascript/account.js
+++ b/src/public/javascript/account.js
@@ -11,7 +11,7 @@ $(document).ready(function(){
     })
 });
 
-// If the new password field is changed, the confirm field gets a red border
+// If the new email field is changed, the confirm field gets a red border
 $(document).ready(function(){
     $("#email").on("input", function(){
         document.getElementById("email").style.borderColor = "#ced4da";
@@ -23,7 +23,7 @@ $(document).ready(function(){
     })
 });
 
-// The confirm password field loses its red border when password values equal
+// The confirm email field loses its red border when email values equal
 $(document).ready(function(){
     $("#email-confirm").on("input", function(){
         if($("#email").val() == $("#email-confirm").val()){
@@ -35,6 +35,18 @@ $(document).ready(function(){
 });
 
 // Passwords
+
+// When old password is input, prompt for new password
+$(document).ready(function(){
+    $("#old-password").on("input", function(){
+        if($("#password").val() == ""){
+            document.getElementById("password").style.borderColor = "red";
+        }
+        if($("#password-confirm").val() == ""){
+            document.getElementById("password-confirm").style.borderColor = "red";
+        }
+    })
+});
 
 // If the new password field is changed, the confirm field gets a red border
 $(document).ready(function(){
@@ -73,6 +85,12 @@ function validate(event) {
     var emailconf = $("#email-confirm").val();
     if (email == emailconf) {
         mismatch_email = false;
+    }
+
+    // If old password is filled in and new password is empty
+    if($("#old-password").val() != "" && $("#password").val() == ""){
+        event.preventDefault();
+        alert("Please enter a new password or remove your old password");
     }
 
     // Password validation

--- a/src/resources/views/account.blade.php
+++ b/src/resources/views/account.blade.php
@@ -18,7 +18,7 @@
                       <div class="form-group row">
                           <label class="col-md-4 col-form-label text-md-right" for="fname">First Name</label>
                           <div class="col-md-6">
-                              <input id="fname" type="text" class="form-control @error('name') is-invalid @enderror" name="fname" placeholder="{{auth()->user()->first_name}}">
+                              <input id="fname" type="text" class="form-control @error('name') is-invalid @enderror" name="fname" autocomplete="given-name" placeholder="{{auth()->user()->first_name}}">
                               @error('name')
                                   <span class="invalid-feedback" role="alert">
                                       <strong>{{ $message }}</strong>
@@ -31,7 +31,7 @@
                             <label class="col-md-4 col-form-label text-md-right" for="lname">Last Name</label>
                             <div class="col-md-6">
                               <!-- TODO make placeholder first name -->
-                                <input id="lname" type="text" class="form-control @error('name') is-invalid @enderror" name="lname" placeholder="{{auth()->user()->last_name}}">
+                                <input id="lname" type="text" class="form-control @error('name') is-invalid @enderror" name="lname" autocomplete="family-name" placeholder="{{auth()->user()->last_name}}">
 
                                 @error('name')
                                     <span class="invalid-feedback" role="alert">
@@ -111,7 +111,7 @@
                         <label for="old-password" class="col-md-4 col-form-label text-md-right">Old Password</label>
 
                         <div class="col-md-6">
-                            <input id="old-password" type="password" class="form-control @error('password') is-invalid @enderror" name="old-password" placeholder="Old Password">
+                            <input id="old-password" type="password" class="form-control @error('password') is-invalid @enderror" name="old-password" autocomplete="current-password" placeholder="Old Password">
 
                             @error('password')
                                 <span class="invalid-feedback" role="alert">
@@ -125,7 +125,7 @@
                         <label for="password" class="col-md-4 col-form-label text-md-right">New Password</label>
 
                         <div class="col-md-6">
-                            <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" placeholder="New Password" pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$" onchange="this.setCustomValidity(this.validity.patternMismatch ? 'Password must have at least 8 characters. 1 upper case, 1 lower case, 1 number, and 1 special character' : '');">
+                            <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" autocomplete="new-password" placeholder="New Password" pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$" onchange="this.setCustomValidity(this.validity.patternMismatch ? 'Password must have at least 8 characters. 1 upper case, 1 lower case, 1 number, and 1 special character' : '');">
 
                             @error('password')
                                 <span class="invalid-feedback" role="alert">
@@ -139,7 +139,7 @@
                         <label for="password-confirm" class="col-md-4 col-form-label text-md-right">Confirm New Password</label>
 
                         <div class="col-md-6">
-                            <input id="password-confirm" type="password" class="form-control" name="password-confirm" placeholder="Confirm New Password">
+                            <input id="password-confirm" type="password" class="form-control" name="password-confirm" autocomplete="new-password" placeholder="Confirm New Password">
                         </div>
                     </div>
 

--- a/src/tests/Feature/AccountControllerTest.php
+++ b/src/tests/Feature/AccountControllerTest.php
@@ -61,6 +61,7 @@ class AccountControllerTest extends TestCase
             ->post('/account', [
                 'old-email' => $user->email,
                 'email' => 'test_email@example.com',
+                'email-confirm' => 'test_email@example.com',
             ]);
         $this->assertEquals('Email changed successfully!', session('email_message'));
         $this->assertEquals('test_email@example.com', $user->email);
@@ -74,6 +75,7 @@ class AccountControllerTest extends TestCase
             ->post('/account', [
                 'old-password' => 'password',
                 'password' => 'this_is_a_new_password',
+                'password-confirm' => 'this_is_a_new_password',
             ]);
         $this->assertEquals('Password changed successfully!', session('password_message'));
         $this->assertEquals(true, Hash::check('this_is_a_new_password', $user->password));
@@ -87,8 +89,23 @@ class AccountControllerTest extends TestCase
             ->post('/account', [
                 'old-email' => 'asdf',
                 'email' => 'asdf',
+                'email-confirm' => 'asdf',
             ]);
         $this->assertEquals('Old Email does not match current email.', session('email_error'));
+        $this->assertEquals($user_oldemail, $user->email);
+    }
+
+    public function test_user_update_with_blank_email_account()
+    {
+        $user = User::factory()->create();
+        $user_oldemail = $user->email;
+        $this->actingAs($user)
+            ->post('/account', [
+                'old-email' => $user_oldemail,
+                'email' => NULL,
+                'email-confirm' => NULL,
+            ]);
+        $this->assertEquals('Please fill in all the fields.', session('email_error'));
         $this->assertEquals($user_oldemail, $user->email);
     }
 
@@ -106,6 +123,7 @@ class AccountControllerTest extends TestCase
             ->post('/account', [
                 'old-email' => $userOneOldEmail,
                 'email' => $userTwoEmail,
+                'email-confirm' => $userTwoEmail,
             ]);
 
         $this->assertEquals('That email is already in use.', session('email_error'));
@@ -120,8 +138,23 @@ class AccountControllerTest extends TestCase
             ->post('/account', [
                 'old-password' => 'incorrect_password',
                 'password' => 'this_is_a_new_password',
+                'password-confirm' => 'this_is_a_new_password',
             ]);
         $this->assertEquals('Incorrect Password.', session('password_error'));
+        $this->assertEquals(true, Hash::check('password', $user->password));
+    }
+
+    public function test_user_blank_password()
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post('/account', [
+                'old-password' => 'password',
+                'password' => NULL,
+                'password-confirm' => NULL,
+            ]);
+        $this->assertEquals('Please fill in all the fields.', session('password_error'));
         $this->assertEquals(true, Hash::check('password', $user->password));
     }
 }


### PR DESCRIPTION
# UPEI Behavior Rating Tool PR

IMPORTANT: The backend should also be changed to check for this error

## What are the contents of this PR?

- [ ] Refactor
- [ ] New Feature
- [ ] Optimization
- [ ] Documentation
- [X] Bug Fix
- [ ] Configuration
- [ ] Breaking Change

## Describe the PR

Error reported when submitting the form with an old email but no new email. I think a check should be put in the backend as well.

## Related issue

Closes #157 
Closes #158 

## Checklist

- [X] My code follows the same style of the project
- [ ] My code requires an update to the documentation
- [ ] I have updated the documentation as required
- [ ] I have added the required unit/feature tests
- [X] All tests were successful

## Testing

Try to update your account with an old email but no new email. Fields should turn red and the form should not submit.